### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/752/473/101752473.geojson
+++ b/data/101/752/473/101752473.geojson
@@ -422,6 +422,9 @@
         "wk:page":"Kerch"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ecfd277f7cffe13a0c48d370d02357c6",
     "wof:hierarchy":[
         {
@@ -446,7 +449,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566595778,
+    "wof:lastmodified":1582314090,
     "wof:name":"\u041a\u0435\u0440\u0447",
     "wof:parent_id":1108738673,
     "wof:placetype":"locality",

--- a/data/101/857/003/101857003.geojson
+++ b/data/101/857/003/101857003.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q2667556"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"632f470acae97a95aad30c09447fd909",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101857003,
-    "wof:lastmodified":1566595786,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041e\u0440\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087913,
     "wof:placetype":"locality",

--- a/data/101/857/007/101857007.geojson
+++ b/data/101/857/007/101857007.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"abbe4596fc49e6134241ae2981310dfb",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101857007,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0414\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087913,
     "wof:placetype":"locality",

--- a/data/101/857/009/101857009.geojson
+++ b/data/101/857/009/101857009.geojson
@@ -164,6 +164,9 @@
         "wk:page":"Reni, Ukraine"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e06dd668933f1869033a0bd04be4dc05",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":101857009,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0420\u0435\u043d\u0456",
     "wof:parent_id":102087913,
     "wof:placetype":"locality",

--- a/data/101/857/201/101857201.geojson
+++ b/data/101/857/201/101857201.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4105602"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e65f798dce6b3274e8ab9b9254951a1",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101857201,
-    "wof:lastmodified":1566595786,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0412\u0432\u0435\u0434\u0435\u043d\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/857/205/101857205.geojson
+++ b/data/101/857/205/101857205.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4477958"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbf9aaeb8c75377d6df48783a109412a",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101857205,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0423\u0441\u043f\u0435\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/857/207/101857207.geojson
+++ b/data/101/857/207/101857207.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q4240623"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c147b91f416bd518f0ff1fb721e333b5",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101857207,
-    "wof:lastmodified":1566595786,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041a\u0440\u0438\u0432\u0430 \u0411\u0430\u043b\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/857/225/101857225.geojson
+++ b/data/101/857/225/101857225.geojson
@@ -107,6 +107,9 @@
         "wd:id":"Q985537"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b11e69946ba1c9105373dd6e5b46a977",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101857225,
-    "wof:lastmodified":1566595786,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0412\u0435\u0441\u0435\u043b\u0430 \u0414\u043e\u043b\u0438\u043d\u0430",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/857/227/101857227.geojson
+++ b/data/101/857/227/101857227.geojson
@@ -62,6 +62,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b90b843694a43ffa1c529555020754ec",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101857227,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041f\u0456\u0434\u0433\u0456\u0440\u043d\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/857/229/101857229.geojson
+++ b/data/101/857/229/101857229.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3471e6f43ed4e5d7dd0d90e1126af8b5",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101857229,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0421\u0430\u043b\u0433\u0430\u043d\u0438",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/857/231/101857231.geojson
+++ b/data/101/857/231/101857231.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59cf712761351ceb97df56711f669cf0",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101857231,
-    "wof:lastmodified":1566595786,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0411\u0440\u0438\u0442\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/857/233/101857233.geojson
+++ b/data/101/857/233/101857233.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1855bb13ab3ed23bef6f246346e947a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101857233,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0421\u0443\u0445\u043e\u043b\u0443\u0436\u0436\u044f",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/857/235/101857235.geojson
+++ b/data/101/857/235/101857235.geojson
@@ -153,6 +153,9 @@
         "wd:id":"Q2886522"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"127ce869b0b5767f96dae0d7221f80a5",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101857235,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041c\u043e\u043b\u043e\u0433\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/857/237/101857237.geojson
+++ b/data/101/857/237/101857237.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1fd75571d3185bfe0cd80ada1ea1f9ba",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101857237,
-    "wof:lastmodified":1566595786,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0410\u043d\u0434\u0440\u0456\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/857/303/101857303.geojson
+++ b/data/101/857/303/101857303.geojson
@@ -64,6 +64,9 @@
         "qs_pg:id":82663
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2cc41b36ed9e5b89f9ba7174cf2e182d",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":101857303,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041a\u0430\u0440\u043e\u043b\u0456\u043d\u043e-\u0411\u0443\u0433\u0430\u0437",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/857/305/101857305.geojson
+++ b/data/101/857/305/101857305.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q4396915"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7811663c5bfad30711c6ab65b7190ae",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101857305,
-    "wof:lastmodified":1566595786,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0420\u043e\u043a\u0441\u043e\u043b\u0430\u043d\u0438",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/857/307/101857307.geojson
+++ b/data/101/857/307/101857307.geojson
@@ -100,6 +100,9 @@
         "wd:id":"Q22736823"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"291b0759032b2a6b3d311ec8471a0334",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101857307,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0414\u0430\u043b\u044c\u043d\u0438\u043a",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/857/309/101857309.geojson
+++ b/data/101/857/309/101857309.geojson
@@ -658,6 +658,9 @@
         "wd:id":"Q7918"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"453dedf643ffa4a7091734cf889b6cd8",
     "wof:hierarchy":[
         {
@@ -669,7 +672,7 @@
         }
     ],
     "wof:id":101857309,
-    "wof:lastmodified":1566595785,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0411\u0430\u0440\u0430\u0431\u043e\u0439",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/858/315/101858315.geojson
+++ b/data/101/858/315/101858315.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q2976084"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fffe451fd39f1380a2bc2ade9c65f25c",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858315,
-    "wof:lastmodified":1566595791,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041d\u043e\u0432\u043e\u0441\u0456\u043b\u044c\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087913,
     "wof:placetype":"locality",

--- a/data/101/858/317/101858317.geojson
+++ b/data/101/858/317/101858317.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Plavni"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf58c6b38849592c8e2789c1b2c13857",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101858317,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041f\u043b\u0430\u0432\u043d\u0456",
     "wof:parent_id":102087913,
     "wof:placetype":"locality",

--- a/data/101/858/321/101858321.geojson
+++ b/data/101/858/321/101858321.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46aeae1c6e4efa6d27e460d0c4e4e9bd",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858321,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041d\u0430\u0433\u0456\u0440\u043d\u0435",
     "wof:parent_id":102087913,
     "wof:placetype":"locality",

--- a/data/101/858/323/101858323.geojson
+++ b/data/101/858/323/101858323.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q2976047"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf559225353947012ef71b49dd808451",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858323,
-    "wof:lastmodified":1566595791,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041b\u0438\u043c\u0430\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087913,
     "wof:placetype":"locality",

--- a/data/101/858/325/101858325.geojson
+++ b/data/101/858/325/101858325.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Kotlovyna"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1bb6aa8fed7ca2bd4dcfb5ac0417cb5",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101858325,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041a\u043e\u0442\u043b\u043e\u0432\u0438\u043d\u0430",
     "wof:parent_id":102087913,
     "wof:placetype":"locality",

--- a/data/101/858/327/101858327.geojson
+++ b/data/101/858/327/101858327.geojson
@@ -50,6 +50,9 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc3759cf52169dd3c1366c7819d82922",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101858327,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0421\u0442\u0430\u0440\u0430 \u041d\u0435\u043a\u0440\u0430\u0441\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/329/101858329.geojson
+++ b/data/101/858/329/101858329.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q4284997"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e9a939e808de6e610f35c55fad2cd83",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858329,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041c\u0430\u0442\u0440\u043e\u0441\u044c\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/331/101858331.geojson
+++ b/data/101/858/331/101858331.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q2391987"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66e47c6ed3e992daabcdd4565df98a47",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858331,
-    "wof:lastmodified":1566595787,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041d\u043e\u0432\u0430 \u041d\u0435\u043a\u0440\u0430\u0441\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/333/101858333.geojson
+++ b/data/101/858/333/101858333.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q4254499"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f936be85a7b9c37a439813516d4a27e4",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858333,
-    "wof:lastmodified":1566595794,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041b\u0430\u0440\u0436\u0430\u043d\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/335/101858335.geojson
+++ b/data/101/858/335/101858335.geojson
@@ -99,6 +99,9 @@
         "wd:id":"Q2582074"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"407e6bedc1820a69abbc47a7ee0749be",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101858335,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0411\u0440\u043e\u0441\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/339/101858339.geojson
+++ b/data/101/858/339/101858339.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q1981858"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"165b8a6bfb8747041de94de497ab45bf",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101858339,
-    "wof:lastmodified":1566595787,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0421\u0430\u0444'\u044f\u043d\u0438",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/341/101858341.geojson
+++ b/data/101/858/341/101858341.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q4332333"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74fec6c58a1146a471431daa813086f4",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101858341,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041e\u0437\u0435\u0440\u043d\u0435",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/343/101858343.geojson
+++ b/data/101/858/343/101858343.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23c3bcf46a3464222eb374bfd6f90855",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858343,
-    "wof:lastmodified":1566595798,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0411\u0430\u0433\u0430\u0442\u0435",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/345/101858345.geojson
+++ b/data/101/858/345/101858345.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94574a6197ea8a717c44394d6afbf7bc",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858345,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041a\u0438\u0441\u043b\u0438\u0446\u044f",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/347/101858347.geojson
+++ b/data/101/858/347/101858347.geojson
@@ -52,6 +52,9 @@
         "gp:id":12518266
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5223c4744d2e082ac6bd964fadc7a1b5",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858347,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041b\u043e\u0449\u0438\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/349/101858349.geojson
+++ b/data/101/858/349/101858349.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25290011a659ac9874c3ac1cd4ec34ce",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858349,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041f\u0435\u0440\u0448\u043e\u0442\u0440\u0430\u0432\u043d\u0435\u0432\u0435",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/351/101858351.geojson
+++ b/data/101/858/351/101858351.geojson
@@ -62,6 +62,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00068c0c28c97011fefd307689f2940f",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101858351,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0423\u0442\u043a\u043e\u043d\u043e\u0441\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/353/101858353.geojson
+++ b/data/101/858/353/101858353.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8dee74286af88cba04c3817e95a3dd0f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858353,
-    "wof:lastmodified":1566595787,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041a\u043e\u043c\u0438\u0448\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/357/101858357.geojson
+++ b/data/101/858/357/101858357.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q2583497"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1b4acffce95d4b0845b2fc0962265b3",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858357,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041a\u0430\u043b\u0430\u043d\u0447\u0430\u043a",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/359/101858359.geojson
+++ b/data/101/858/359/101858359.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q1981416"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a593a802ccf4c8d8f61fa0a75040012",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858359,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041c\u0443\u0440\u0430\u0432\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/361/101858361.geojson
+++ b/data/101/858/361/101858361.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a2af0152a4abe774097a07b85c245d2",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858361,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041a\u0430\u043c'\u044f\u043d\u043a\u0430",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/363/101858363.geojson
+++ b/data/101/858/363/101858363.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2705a0b19e44d5227316f077fcd195b0",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858363,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041a\u0438\u0440\u043d\u0438\u0447\u043a\u0438",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/365/101858365.geojson
+++ b/data/101/858/365/101858365.geojson
@@ -93,6 +93,9 @@
         "wd:id":"Q204164"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9d7799cf0ac36ac09df1760a05227f5",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101858365,
-    "wof:lastmodified":1566595787,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0421\u0443\u0432\u043e\u0440\u043e\u0432\u0435",
     "wof:parent_id":102087917,
     "wof:placetype":"locality",

--- a/data/101/858/367/101858367.geojson
+++ b/data/101/858/367/101858367.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9cdf6dca3fd084efb383ac39c3a1ee04",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858367,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041b\u0456\u0441\u043a\u0438",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/369/101858369.geojson
+++ b/data/101/858/369/101858369.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q339707"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d96fc2e5cd91f37b1913409452638086",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858369,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041f\u0440\u0438\u043c\u043e\u0440\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/371/101858371.geojson
+++ b/data/101/858/371/101858371.geojson
@@ -53,6 +53,9 @@
         "gp:id":937122
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bd018277a08fed8a53900e120cc71de",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858371,
-    "wof:lastmodified":1566595791,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0412\u0430\u0441\u0438\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/375/101858375.geojson
+++ b/data/101/858/375/101858375.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q25024"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a08a074e467caf4659c019032ea60d35",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858375,
-    "wof:lastmodified":1566595798,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0428\u0435\u0432\u0447\u0435\u043d\u043a\u043e\u0432\u0435",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/377/101858377.geojson
+++ b/data/101/858/377/101858377.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84ee571340213908cba0d846d8b6075e",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858377,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0414\u0435\u0441\u0430\u043d\u0442\u043d\u0435",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/379/101858379.geojson
+++ b/data/101/858/379/101858379.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc4654ff46e1337adeae5e631eba4bbc",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858379,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041c\u0438\u0440\u043d\u0435",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/381/101858381.geojson
+++ b/data/101/858/381/101858381.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q658267"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ef52f1b48548f4d3685c37f65a07194b",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101858381,
-    "wof:lastmodified":1566595798,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041f\u0440\u0438\u043e\u0437\u0435\u0440\u043d\u0435",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/383/101858383.geojson
+++ b/data/101/858/383/101858383.geojson
@@ -66,6 +66,9 @@
         "wd:id":"Q5564197"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8118143955c3aaa218e4ad7f8836e9ca",
     "wof:hierarchy":[
         {
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":101858383,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0422\u0440\u0443\u0434\u043e\u0432\u0435",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/385/101858385.geojson
+++ b/data/101/858/385/101858385.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Furmanivka"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f21a0ac9f8f5b9c2e90d61cdd4726a19",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101858385,
-    "wof:lastmodified":1566595791,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0424\u0443\u0440\u043c\u0430\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/387/101858387.geojson
+++ b/data/101/858/387/101858387.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c9b39254154bca546d4a109a11da5e30",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858387,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0414\u043c\u0438\u0442\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/389/101858389.geojson
+++ b/data/101/858/389/101858389.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"21195c1bbc53a11c5816f6112ff4d32f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858389,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0421\u0442\u0430\u0440\u0456 \u0422\u0440\u043e\u044f\u043d\u0438",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/393/101858393.geojson
+++ b/data/101/858/393/101858393.geojson
@@ -65,6 +65,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af90c704d385bda1e0c3a35c90eb5169",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":101858393,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041d\u043e\u0432\u043e\u0441\u0435\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/395/101858395.geojson
+++ b/data/101/858/395/101858395.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Kiliya"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eca4d0acc5a8c31f977cf1f5ac0d0a23",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":101858395,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041a\u0456\u043b\u0456\u044f",
     "wof:parent_id":102087919,
     "wof:placetype":"locality",

--- a/data/101/858/397/101858397.geojson
+++ b/data/101/858/397/101858397.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5dffc9078360dc2b2b7c493436c8f41e",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858397,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041a\u0440\u0438\u043d\u0438\u0447\u043d\u0435",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/399/101858399.geojson
+++ b/data/101/858/399/101858399.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q2425958"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6a8cf6c317938909feb38167bf4bc255",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858399,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0412\u043b\u0430\u0434\u0438\u0447\u0435\u043d\u044c",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/401/101858401.geojson
+++ b/data/101/858/401/101858401.geojson
@@ -95,6 +95,9 @@
         "wd:id":"Q2668368"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30ad9da2b2264ff115029d581594fd07",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101858401,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0416\u043e\u0432\u0442\u043d\u0435\u0432\u0435",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/403/101858403.geojson
+++ b/data/101/858/403/101858403.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"216a5a503977a620d8a9ccad2f866446",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858403,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0412\u0430\u0441\u0438\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/405/101858405.geojson
+++ b/data/101/858/405/101858405.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1028360
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b2253df37cbb25f3b744caea8e1f72c",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":101858405,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0412\u0438\u043d\u043e\u0433\u0440\u0430\u0434\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/407/101858407.geojson
+++ b/data/101/858/407/101858407.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q2581674"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10d287e8a5eff7d19a3ac7e6b3c7682b",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858407,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0411\u0430\u043d\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/411/101858411.geojson
+++ b/data/101/858/411/101858411.geojson
@@ -105,6 +105,9 @@
         "wd:id":"Q2478374"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7948a7c6a93a91955139939bae61b459",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":101858411,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041a\u0430\u043b\u0447\u0435\u0432\u0430",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/413/101858413.geojson
+++ b/data/101/858/413/101858413.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2663d021e75b5af245567a4d517d9ee0",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858413,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0413\u043e\u043b\u0438\u0446\u044f",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/415/101858415.geojson
+++ b/data/101/858/415/101858415.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q2583165"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3d20339b353015ce637e41baa4ca93c",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101858415,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0427\u0435\u0440\u0432\u043e\u043d\u043e\u0430\u0440\u043c\u0456\u0439\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/417/101858417.geojson
+++ b/data/101/858/417/101858417.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ef0a34a0e1efae2418ee96e8159586d",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858417,
-    "wof:lastmodified":1566595794,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0412\u0438\u043d\u043e\u0433\u0440\u0430\u0434\u043d\u0435",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/419/101858419.geojson
+++ b/data/101/858/419/101858419.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23caa687000e26e0f7428fdaecbfc31a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858419,
-    "wof:lastmodified":1566595794,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041e\u0440\u0456\u0445\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/421/101858421.geojson
+++ b/data/101/858/421/101858421.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q2583523"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3961ba459e41903526b9e8f840abb38a",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101858421,
-    "wof:lastmodified":1566595794,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041e\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/423/101858423.geojson
+++ b/data/101/858/423/101858423.geojson
@@ -99,6 +99,9 @@
         "wd:id":"Q2472524"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7294f41deb29f227f978e145d41130dc",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101858423,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0413\u043e\u0440\u043e\u0434\u043d\u0454",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/425/101858425.geojson
+++ b/data/101/858/425/101858425.geojson
@@ -95,6 +95,9 @@
         "wd:id":"Q2581621"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"752b4d15605021aa8bf3995573bf2f72",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101858425,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041d\u043e\u0432\u0456 \u0422\u0440\u043e\u044f\u043d\u0438",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/429/101858429.geojson
+++ b/data/101/858/429/101858429.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q4162983"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"368045d6ded6b6159de6a73707431e2d",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858429,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0414\u043c\u0438\u0442\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/431/101858431.geojson
+++ b/data/101/858/431/101858431.geojson
@@ -187,6 +187,9 @@
         "wk:page":"Bolhrad"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"21547131692a92c7fdd76582079946ff",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
         }
     ],
     "wof:id":101858431,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0411\u043e\u043b\u0433\u0440\u0430\u0434",
     "wof:parent_id":102087923,
     "wof:placetype":"locality",

--- a/data/101/858/433/101858433.geojson
+++ b/data/101/858/433/101858433.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4317578"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9511a782b09c53ea450afa7152b16bda",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858433,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041d\u0435\u0440\u0443\u0448\u0430\u0439",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/435/101858435.geojson
+++ b/data/101/858/435/101858435.geojson
@@ -157,6 +157,9 @@
         "wd:id":"Q2234641"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7097c3fc81dc110543e2b7ad64bd71ce",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":101858435,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041b\u0438\u043c\u0430\u043d",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/437/101858437.geojson
+++ b/data/101/858/437/101858437.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q339707"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01666b0a0f77ed9a4a1019ff89158015",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858437,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041f\u0440\u0438\u043c\u043e\u0440\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/439/101858439.geojson
+++ b/data/101/858/439/101858439.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4444380"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ffe83f7bbffb027b1738ff5ac5c39d86",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858439,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0421\u0442\u0440\u0443\u043c\u043e\u043a",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/441/101858441.geojson
+++ b/data/101/858/441/101858441.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":2
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e61cebb9fc5a6bc54707d52105856d3",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858441,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0413\u043b\u0438\u0431\u043e\u043a\u0435",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/443/101858443.geojson
+++ b/data/101/858/443/101858443.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"333fb0c9ab6d59e2794a6385ab86fee9",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858443,
-    "wof:lastmodified":1566595794,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0411\u043e\u0440\u0438\u0441\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/447/101858447.geojson
+++ b/data/101/858/447/101858447.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4462199"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b064ec61159f9c94b41c03dd348b792c",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858447,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0422\u0440\u0430\u043f\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/449/101858449.geojson
+++ b/data/101/858/449/101858449.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66801a4110435cf03b972c4c65e827c9",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858449,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0412\u0438\u0448\u043d\u0435\u0432\u0435",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/451/101858451.geojson
+++ b/data/101/858/451/101858451.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35737464fb5ea66461785a0f307735be",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858451,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0414\u043c\u0438\u0442\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/453/101858453.geojson
+++ b/data/101/858/453/101858453.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q2033400"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1272004b8f3450a3df448ed24e963e3",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858453,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0422\u0443\u0437\u043b\u0438",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/455/101858455.geojson
+++ b/data/101/858/455/101858455.geojson
@@ -65,6 +65,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb023500adf0bcef0c8d9287e1ba3078",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":101858455,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0411\u0430\u0437\u0430\u0440'\u044f\u043d\u043a\u0430",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/457/101858457.geojson
+++ b/data/101/858/457/101858457.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b95823daabc2e60d9e92e70e12080c2",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858457,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0411\u0456\u043b\u043e\u043b\u0456\u0441\u0441\u044f",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/459/101858459.geojson
+++ b/data/101/858/459/101858459.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a44fb0d1a55916ec3e231bb14d8d0a2b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858459,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0414\u0438\u0432\u0456\u0437\u0456\u044f",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/461/101858461.geojson
+++ b/data/101/858/461/101858461.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Tatarbunary"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f44512ef4824c10e2dbdea459e985c2",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":101858461,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0422\u0430\u0442\u0430\u0440\u0431\u0443\u043d\u0430\u0440\u0438",
     "wof:parent_id":102087929,
     "wof:placetype":"locality",

--- a/data/101/858/465/101858465.geojson
+++ b/data/101/858/465/101858465.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ccf784fa7ce701d3ac15fa730761a30",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858465,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0425\u043e\u043b\u043c\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/467/101858467.geojson
+++ b/data/101/858/467/101858467.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0b47ef2e7b71a0450cd10ad5626a26fb",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858467,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041e\u0441\u0442\u0440\u0456\u0432\u043d\u0435",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/469/101858469.geojson
+++ b/data/101/858/469/101858469.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6abfe4bca9920b5e0c810345d2741118",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858469,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041a\u0430\u043c'\u044f\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/471/101858471.geojson
+++ b/data/101/858/471/101858471.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e0e0a19e30e97f822fc25d8dd4d3f33c",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858471,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0412\u0438\u043d\u043e\u0433\u0440\u0430\u0434\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/473/101858473.geojson
+++ b/data/101/858/473/101858473.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c309e340b5b08450daf33653d32e41f8",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858473,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0417\u0430\u0434\u0443\u043d\u0430\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/475/101858475.geojson
+++ b/data/101/858/475/101858475.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q3622362"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6dbb240f8abb15a27aca17aafdf03f51",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858475,
-    "wof:lastmodified":1566595794,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0413\u043b\u0430\u0432\u0430\u043d\u0456",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/477/101858477.geojson
+++ b/data/101/858/477/101858477.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q978840"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"520edf79e0910966204bcce5ba8358c7",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101858477,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041f\u0440\u044f\u043c\u043e\u0431\u0430\u043b\u043a\u0430",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/479/101858479.geojson
+++ b/data/101/858/479/101858479.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q994389"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ffe722f8dab2e6b5ab70afbc78b8217",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101858479,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0414\u0435\u043b\u0435\u043d\u044c",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/483/101858483.geojson
+++ b/data/101/858/483/101858483.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84e133d82500c37ce89d78b848b3a2a1",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858483,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041d\u043e\u0432\u0430 \u0406\u0432\u0430\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/485/101858485.geojson
+++ b/data/101/858/485/101858485.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q2887542"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"507cc415acc79cef13ce8a7f1eebf1c5",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101858485,
-    "wof:lastmodified":1566595788,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041f\u0430\u0432\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/487/101858487.geojson
+++ b/data/101/858/487/101858487.geojson
@@ -126,6 +126,9 @@
         "wd:id":"Q455246"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13d8ba771d970529ccacf7f9a8d4c136",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":101858487,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0422\u0435\u043f\u043b\u0438\u0446\u044f",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/489/101858489.geojson
+++ b/data/101/858/489/101858489.geojson
@@ -62,6 +62,9 @@
         "gp:id":929037
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"629a4d11a22984fcce9cd42834ac99a5",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101858489,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0421\u0430\u0434\u043e\u0432\u0435",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/491/101858491.geojson
+++ b/data/101/858/491/101858491.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q639763"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"158f45a34ec5c79efefa83984be8aeb1",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858491,
-    "wof:lastmodified":1566595790,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0412\u0435\u0441\u0435\u043b\u0438\u0439 \u041a\u0443\u0442",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/493/101858493.geojson
+++ b/data/101/858/493/101858493.geojson
@@ -59,6 +59,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e2ecdb2ebf9c6bae193f4370e6f0240",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101858493,
-    "wof:lastmodified":1566595795,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041c\u0438\u0440\u043d\u043e\u043f\u0456\u043b\u043b\u044f",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/495/101858495.geojson
+++ b/data/101/858/495/101858495.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4114812"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59935f9972e3488103a0701363f039b7",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101858495,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0412\u043e\u0437\u043d\u0435\u0441\u0435\u043d\u043a\u0430 \u041f\u0435\u0440\u0448\u0430",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/497/101858497.geojson
+++ b/data/101/858/497/101858497.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Artsyz"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72541080684bfe0c6055cfb5faf1bc5a",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":101858497,
-    "wof:lastmodified":1566595789,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0410\u0440\u0446\u0438\u0437",
     "wof:parent_id":102087931,
     "wof:placetype":"locality",

--- a/data/101/858/523/101858523.geojson
+++ b/data/101/858/523/101858523.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1cfa3d3619128841312db645e6b19629",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858523,
-    "wof:lastmodified":1566595798,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041c\u0438\u0445\u0430\u0439\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/525/101858525.geojson
+++ b/data/101/858/525/101858525.geojson
@@ -96,6 +96,9 @@
         "wd:id":"Q4187759"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ae4ae621ccc0e98c00a1a6c6c70e9bb",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101858525,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0417\u043e\u0440\u044f",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/527/101858527.geojson
+++ b/data/101/858/527/101858527.geojson
@@ -52,6 +52,9 @@
         "gp:id":923105
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0464338e73f5848c667367a7b5db5330",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858527,
-    "wof:lastmodified":1566595791,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0421\u0435\u0440\u0433\u0456\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/529/101858529.geojson
+++ b/data/101/858/529/101858529.geojson
@@ -62,6 +62,9 @@
         "gp:id":929036
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05084af5927fcd99289604a9bbcd6f20",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101858529,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041d\u043e\u0432\u043e\u0441\u0435\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/531/101858531.geojson
+++ b/data/101/858/531/101858531.geojson
@@ -99,6 +99,9 @@
         "wd:id":"Q2083559"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4ae2a59ef534cb188a5c86c154884a4",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101858531,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041a\u0443\u043b\u0435\u0432\u0447\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/533/101858533.geojson
+++ b/data/101/858/533/101858533.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4538799"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c068b46bdd40a47f6f7e4f97dc80ddb1",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858533,
-    "wof:lastmodified":1566595787,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u042f\u0440\u043e\u0441\u043b\u0430\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/537/101858537.geojson
+++ b/data/101/858/537/101858537.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q4410411"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c48ef91adeecf323e6bb2146f3cf270",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101858537,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0421\u0432\u0456\u0442\u043b\u043e\u0434\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/539/101858539.geojson
+++ b/data/101/858/539/101858539.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q4364755"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84624f2822b1158ea58db3ed0d56a7f0",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101858539,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041f\u043b\u0430\u0445\u0442\u0456\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/541/101858541.geojson
+++ b/data/101/858/541/101858541.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4320223"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed984da4178f81e790c323d59183e4e3",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101858541,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041c\u0438\u043a\u043e\u043b\u0430\u0457\u0432\u043a\u0430-\u041d\u043e\u0432\u043e\u0440\u043e\u0441\u0456\u0439\u0441\u044c\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/543/101858543.geojson
+++ b/data/101/858/543/101858543.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Sarata"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4835b6c8e1294de4bc6bb45bfbefad50",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101858543,
-    "wof:lastmodified":1566595791,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0421\u0430\u0440\u0430\u0442\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/858/565/101858565.geojson
+++ b/data/101/858/565/101858565.geojson
@@ -54,6 +54,9 @@
         "wd:id":"Q5501068"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37e060854de9b5e8f35b014e8c7d45b1",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":101858565,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0412\u0456\u043b\u044c\u043d\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/858/567/101858567.geojson
+++ b/data/101/858/567/101858567.geojson
@@ -292,6 +292,9 @@
         "wd:id":"Q156739"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7091bb59c76632a014002041f88e4354",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         }
     ],
     "wof:id":101858567,
-    "wof:lastmodified":1566595787,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0420\u0456\u0432\u043d\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/858/569/101858569.geojson
+++ b/data/101/858/569/101858569.geojson
@@ -90,6 +90,9 @@
         "wd:id":"Q4538712"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3118ad5ab5e9424ca485eea35972a58",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101858569,
-    "wof:lastmodified":1566595786,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u042f\u0440\u043e\u0432\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/858/573/101858573.geojson
+++ b/data/101/858/573/101858573.geojson
@@ -59,6 +59,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53407f030746676d8d8f34af4b945df3",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101858573,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0412\u0438\u043d\u043e\u0433\u0440\u0430\u0434\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/858/575/101858575.geojson
+++ b/data/101/858/575/101858575.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q4238636"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c57417f99557a4f19e93c6a2156aa061",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101858575,
-    "wof:lastmodified":1566595791,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041a\u0440\u0430\u0441\u043d\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/858/577/101858577.geojson
+++ b/data/101/858/577/101858577.geojson
@@ -133,6 +133,9 @@
         "wk:page":"Tarutyne"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be4d1b5f7386c5fd8c694b863fcb55b1",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101858577,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0422\u0430\u0440\u0443\u0442\u0438\u043d\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/858/579/101858579.geojson
+++ b/data/101/858/579/101858579.geojson
@@ -117,6 +117,9 @@
         "wd:id":"Q819118"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b64114c0b177e707e8b94dbd9477f08",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101858579,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0411\u0435\u0440\u0435\u0437\u0438\u043d\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/858/581/101858581.geojson
+++ b/data/101/858/581/101858581.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db6c40a19e9f2f065d18bd86b90c2c6f",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858581,
-    "wof:lastmodified":1566595791,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u041c\u0438\u043a\u043e\u043b\u0430\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/858/583/101858583.geojson
+++ b/data/101/858/583/101858583.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"173c3f112aeba1bfc5ee20d7af45fff9",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858583,
-    "wof:lastmodified":1566595798,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0428\u0438\u0440\u043e\u043a\u0435",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/858/585/101858585.geojson
+++ b/data/101/858/585/101858585.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q339707"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aafdfc8bf6d5e20b9bb9407f7fdac3bd",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101858585,
-    "wof:lastmodified":1566595796,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041f\u0440\u0438\u043c\u043e\u0440\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/858/587/101858587.geojson
+++ b/data/101/858/587/101858587.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d892fe6c233ffe6d47ae21cfde41799",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101858587,
-    "wof:lastmodified":1566595792,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0411\u0456\u043b\u0435\u043d\u044c\u043a\u0435",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/858/591/101858591.geojson
+++ b/data/101/858/591/101858591.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"923d0047b872bf27e6521ec44770474f",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858591,
-    "wof:lastmodified":1566595794,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u041c\u0430\u0440\u0430\u0437\u043b\u0456\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/858/593/101858593.geojson
+++ b/data/101/858/593/101858593.geojson
@@ -79,6 +79,9 @@
         "wd:id":"Q4061767"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f05a8b5cc9ac675bb626eef3f22a06c",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":101858593,
-    "wof:lastmodified":1566595787,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041e\u043b\u0435\u043a\u0441\u0456\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/858/595/101858595.geojson
+++ b/data/101/858/595/101858595.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Shabo, Odessa Oblast"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb27231ca09383c7741d9fc473032efc",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101858595,
-    "wof:lastmodified":1566595787,
+    "wof:lastmodified":1582314093,
     "wof:name":"\u0428\u0430\u0431\u043e",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/858/597/101858597.geojson
+++ b/data/101/858/597/101858597.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8cd9f57d4b398e47e0b40fc1186d406a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101858597,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0421\u0435\u0440\u0433\u0456\u0457\u0432\u043a\u0430",
     "wof:parent_id":1108730627,
     "wof:placetype":"locality",

--- a/data/101/858/599/101858599.geojson
+++ b/data/101/858/599/101858599.geojson
@@ -87,6 +87,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08aed63a6f32700a4dcf162294796c95",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101858599,
-    "wof:lastmodified":1566595793,
+    "wof:lastmodified":1582314094,
     "wof:name":"\u0417\u0430\u0442\u043e\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/858/717/101858717.geojson
+++ b/data/101/858/717/101858717.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Ovidiopol"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d592890bd6ce7e82eb1acfa79e84fab",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":101858717,
-    "wof:lastmodified":1566595797,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041e\u0432\u0456\u0434\u0456\u043e\u043f\u043e\u043b\u044c",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/263/101865263.geojson
+++ b/data/101/865/263/101865263.geojson
@@ -56,6 +56,9 @@
         "gp:id":480247
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51206f3916c214db0e81ccb3276a2f73",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":101865263,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0424\u0430\u0440\u0430\u043e\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/865/265/101865265.geojson
+++ b/data/101/865/265/101865265.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4361513"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46d93415a8ddfb99f7ad4293d343e391",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101865265,
-    "wof:lastmodified":1566595810,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041f\u0435\u0442\u0440\u043e\u043f\u0430\u0432\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/865/269/101865269.geojson
+++ b/data/101/865/269/101865269.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ee01270dc7a616896d2b81daa600f6b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865269,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041c\u0456\u043d\u044f\u0439\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/865/271/101865271.geojson
+++ b/data/101/865/271/101865271.geojson
@@ -59,6 +59,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"758f25a14c781f288d7041ea56a9f904",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101865271,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0421\u0442\u0430\u0440\u043e\u0441\u0456\u043b\u043b\u044f",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/865/273/101865273.geojson
+++ b/data/101/865/273/101865273.geojson
@@ -60,6 +60,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7821e62bcbe8ed862a0a93785ab4a29a",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":101865273,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041c\u0438\u043a\u043e\u043b\u0430\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/865/275/101865275.geojson
+++ b/data/101/865/275/101865275.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q4312026"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f18d7d60491b1196b1674e101dd37b29",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101865275,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041d\u0430\u0434\u0440\u0456\u0447\u043d\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/865/277/101865277.geojson
+++ b/data/101/865/277/101865277.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q4061337"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed2365d2399d5d010f1eafff5b37663e",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101865277,
-    "wof:lastmodified":1566595808,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041e\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/865/279/101865279.geojson
+++ b/data/101/865/279/101865279.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q4361148"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"374966e51c2c4f80786dda71b2532d0e",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101865279,
-    "wof:lastmodified":1566595808,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041f\u0435\u0442\u0440\u0456\u0432\u0441\u044c\u043a",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/865/281/101865281.geojson
+++ b/data/101/865/281/101865281.geojson
@@ -94,6 +94,9 @@
         "wd:id":"Q387287"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b61b9c1a094257fdbff3c4741ee1d9c4",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101865281,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041b\u0456\u0441\u043d\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/865/283/101865283.geojson
+++ b/data/101/865/283/101865283.geojson
@@ -107,6 +107,9 @@
         "wd:id":"Q733631"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d9e54100e474fcfcecfc8dee6ec062d",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101865283,
-    "wof:lastmodified":1566595808,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0421\u0435\u0440\u043f\u043d\u0435\u0432\u0435",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/865/287/101865287.geojson
+++ b/data/101/865/287/101865287.geojson
@@ -67,6 +67,9 @@
         "wd:id":"Q4361001"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"695c6e67f78808353720b82aa84903d8",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":101865287,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041f\u0435\u0442\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/865/289/101865289.geojson
+++ b/data/101/865/289/101865289.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"117fc3359ac7375ac0d55d68acbedcaa",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865289,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041a\u0440\u0430\u0441\u043d\u0430 \u041a\u043e\u0441\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/865/291/101865291.geojson
+++ b/data/101/865/291/101865291.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q4440406"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7845355b97350d35ea35e90f3fc3573",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101865291,
-    "wof:lastmodified":1566595810,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0421\u0442\u0430\u0440\u043e\u043a\u043e\u0437\u0430\u0447\u0435",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/865/293/101865293.geojson
+++ b/data/101/865/293/101865293.geojson
@@ -63,6 +63,9 @@
         "wd:id":"Q2593272"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de10738658ef78d230c1f8428f52ad58",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":101865293,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041a\u043e\u0437\u0430\u0446\u044c\u043a\u0435",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/865/295/101865295.geojson
+++ b/data/101/865/295/101865295.geojson
@@ -55,6 +55,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8651a09547249a5e6865295bc7721549",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":101865295,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041a\u0440\u0443\u0442\u043e\u044f\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/865/297/101865297.geojson
+++ b/data/101/865/297/101865297.geojson
@@ -56,6 +56,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"390586c5944467a9633cb8afacc63a3a",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":101865297,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0420\u0443\u0441\u044c\u043a\u043e\u0456\u0432\u0430\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/865/299/101865299.geojson
+++ b/data/101/865/299/101865299.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7d79435e462959672e63c8ec6cb72129",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865299,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0423\u0434\u043e\u0431\u043d\u0435",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/865/301/101865301.geojson
+++ b/data/101/865/301/101865301.geojson
@@ -265,6 +265,9 @@
         "wd:id":"Q16461831"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66fac057fd4d0fa6da03cb9a7ffac8d3",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         }
     ],
     "wof:id":101865301,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041c\u0438\u043a\u043e\u043b\u0430\u0457\u0432\u043a\u0430",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/305/101865305.geojson
+++ b/data/101/865/305/101865305.geojson
@@ -53,6 +53,9 @@
         "gp:id":921052
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b238d256baf2c12e78719df2d5995572",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101865305,
-    "wof:lastmodified":1566595808,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041c\u043e\u043b\u043e\u0434\u0456\u0436\u043d\u0435",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/307/101865307.geojson
+++ b/data/101/865/307/101865307.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q4099702"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7148f93b75ca3b44b902eb626fcf364",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":101865307,
-    "wof:lastmodified":1566595800,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0411\u0443\u0440\u043b\u0430\u0447\u0430 \u0411\u0430\u043b\u043a\u0430",
     "wof:parent_id":1108730699,
     "wof:placetype":"locality",

--- a/data/101/865/309/101865309.geojson
+++ b/data/101/865/309/101865309.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q4163538"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f9adb89f09c828a9ce3102ffb273a34",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101865309,
-    "wof:lastmodified":1566595800,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0414\u043e\u0431\u0440\u043e\u043e\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/311/101865311.geojson
+++ b/data/101/865/311/101865311.geojson
@@ -79,6 +79,9 @@
         "wd:id":"Q704858"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd80f1e1ac5e866e62dd487da6689782",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":101865311,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u041c\u0430\u043b\u043e\u0434\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":1108730699,
     "wof:placetype":"locality",

--- a/data/101/865/313/101865313.geojson
+++ b/data/101/865/313/101865313.geojson
@@ -72,6 +72,9 @@
         "wd:id":"Q704858"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"077d0a6e2da2cdb22d0053c645506c16",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":101865313,
-    "wof:lastmodified":1566595806,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041d\u043e\u0432\u043e\u0433\u0440\u0430\u0434\u043a\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/315/101865315.geojson
+++ b/data/101/865/315/101865315.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4311994"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7b9ab65f7efe256b8782d7df0137b81",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101865315,
-    "wof:lastmodified":1566595805,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041d\u0430\u0434\u043b\u0438\u043c\u0430\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/317/101865317.geojson
+++ b/data/101/865/317/101865317.geojson
@@ -94,6 +94,9 @@
         "wd:id":"Q4447267"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f8fe7509891294e0f098a1508831306f",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101865317,
-    "wof:lastmodified":1566595813,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0421\u0443\u0445\u0438\u0439 \u041b\u0438\u043c\u0430\u043d",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/319/101865319.geojson
+++ b/data/101/865/319/101865319.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e58455dd92a89a52dd1e3dace512605",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865319,
-    "wof:lastmodified":1566595813,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u041d\u043e\u0432\u0430 \u0414\u043e\u043b\u0438\u043d\u0430",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/323/101865323.geojson
+++ b/data/101/865/323/101865323.geojson
@@ -93,6 +93,9 @@
         "wd:id":"Q956385"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6183b5e8f4f0099042072fdcec7b3511",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101865323,
-    "wof:lastmodified":1566595805,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0419\u043e\u0441\u0438\u043f\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/325/101865325.geojson
+++ b/data/101/865/325/101865325.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df2a16d8274bcb5a238953402d207dae",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865325,
-    "wof:lastmodified":1566595806,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041f\u0440\u0438\u043b\u0438\u043c\u0430\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/327/101865327.geojson
+++ b/data/101/865/327/101865327.geojson
@@ -72,6 +72,9 @@
         "wd:id":"Q704858"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8140191512338093e6739a906e4f6c38",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":101865327,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u041f\u0435\u0442\u0440\u043e\u0434\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/329/101865329.geojson
+++ b/data/101/865/329/101865329.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q4242689"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"942fb59142c7b23a46ac0885922df901",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101865329,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u041a\u0440\u0438\u0436\u0430\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/331/101865331.geojson
+++ b/data/101/865/331/101865331.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q1218961"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b23ffe6fb44f9a3409855fc50724c1cf",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101865331,
-    "wof:lastmodified":1566595800,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041e\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/333/101865333.geojson
+++ b/data/101/865/333/101865333.geojson
@@ -102,6 +102,9 @@
         "wd:id":"Q1026923"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bbe82e9c692040c9fc868a0d0a5a0e08",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101865333,
-    "wof:lastmodified":1566595808,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0412\u0435\u043b\u0438\u043a\u043e\u0434\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/335/101865335.geojson
+++ b/data/101/865/335/101865335.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Tairove"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6fb7044e7e5e79e46f612a5f274550e0",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101865335,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0422\u0430\u0457\u0440\u043e\u0432\u0435",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/337/101865337.geojson
+++ b/data/101/865/337/101865337.geojson
@@ -57,6 +57,9 @@
         "wd:id":"Q6639564"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c15716dd98b035ddd7496d31050f0cc2",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":101865337,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0410\u0432\u0430\u043d\u0433\u0430\u0440\u0434",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/865/341/101865341.geojson
+++ b/data/101/865/341/101865341.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"353d08e69f39163902f29b075220ae01",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101865341,
-    "wof:lastmodified":1566595805,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041c\u0430\u044f\u043a\u0438",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/343/101865343.geojson
+++ b/data/101/865/343/101865343.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25662a4437eb5d1797f4d7a628f33e88",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865343,
-    "wof:lastmodified":1566595813,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u041c\u0438\u0440\u043d\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/345/101865345.geojson
+++ b/data/101/865/345/101865345.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37c41c583320a8359e2a72b334010f04",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865345,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0412\u0435\u043b\u0438\u043a\u0438\u0439 \u0414\u0430\u043b\u044c\u043d\u0438\u043a",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/347/101865347.geojson
+++ b/data/101/865/347/101865347.geojson
@@ -83,6 +83,9 @@
         "wd:id":"Q4539562"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"462e9efbb1c08084ff7c124de46361ef",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101865347,
-    "wof:lastmodified":1566595806,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u042f\u0441\u044c\u043a\u0438",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/349/101865349.geojson
+++ b/data/101/865/349/101865349.geojson
@@ -55,6 +55,9 @@
         "qs_pg:id":909774
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"632b11e52dda70c06cf31a618200c7bc",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":101865349,
-    "wof:lastmodified":1566595806,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0423\u0441\u0430\u0442\u043e\u0432\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/351/101865351.geojson
+++ b/data/101/865/351/101865351.geojson
@@ -63,6 +63,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2be9065ef322452a1c0a9dcf1659897c",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101865351,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0423\u0441\u0430\u0442\u043e\u0432\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/353/101865353.geojson
+++ b/data/101/865/353/101865353.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4c162892eeef367953b4526edd5865c",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865353,
-    "wof:lastmodified":1566595800,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041c\u0430\u0439\u043e\u0440\u0438",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/355/101865355.geojson
+++ b/data/101/865/355/101865355.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ea3b10da836beb40d872f39ee95ca95",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101865355,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0422\u0440\u043e\u0457\u0446\u044c\u043a\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/359/101865359.geojson
+++ b/data/101/865/359/101865359.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4484527f40cc23f8daf02d011325d0be",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865359,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041d\u0435\u0440\u0443\u0431\u0430\u0439\u0441\u044c\u043a\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/361/101865361.geojson
+++ b/data/101/865/361/101865361.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":2
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2302759d6f42cf34d0b133a827e4a2c2",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865361,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0412\u0435\u043b\u0438\u043a\u0430 \u0411\u0430\u043b\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/363/101865363.geojson
+++ b/data/101/865/363/101865363.geojson
@@ -110,6 +110,9 @@
         "wd:id":"Q2392605"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"229ba01dd520cce3c2514d42744e681a",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101865363,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041a\u043e\u0442\u043e\u0432\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/365/101865365.geojson
+++ b/data/101/865/365/101865365.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q4084387"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c150526e278172138b762da20d334a55",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101865365,
-    "wof:lastmodified":1566595800,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0411\u0435\u0440\u0435\u0437\u0430\u043d\u044c",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/367/101865367.geojson
+++ b/data/101/865/367/101865367.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3c849ecc7040a43b8deb19f2704db39",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865367,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0414\u0430\u0447\u043d\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/369/101865369.geojson
+++ b/data/101/865/369/101865369.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q4147383"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7847d93d60e2f44c1a5b94113d32ca8",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101865369,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0413\u0440\u0430\u0434\u0435\u043d\u0438\u0446\u0456",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/371/101865371.geojson
+++ b/data/101/865/371/101865371.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q4207130"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"84ef3fc6a1e0659c3ce1d2e4a5e93ec3",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101865371,
-    "wof:lastmodified":1566595806,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041a\u0430\u0433\u0430\u0440\u043b\u0438\u043a",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/373/101865373.geojson
+++ b/data/101/865/373/101865373.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":2
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d7e28aa0d787a6997483e7b8e4704d1",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865373,
-    "wof:lastmodified":1566595813,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0425\u043e\u043b\u043e\u0434\u043d\u0430 \u0411\u0430\u043b\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/377/101865377.geojson
+++ b/data/101/865/377/101865377.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":8
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1c06d90661ff16d91c882b4a27efe40",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101865377,
-    "wof:lastmodified":1566595805,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0412\u0430\u0441\u0438\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/379/101865379.geojson
+++ b/data/101/865/379/101865379.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q4128764"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"94ad07f97be70e558884279a12cc66af",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101865379,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0412\u0438\u0433\u043e\u0434\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/381/101865381.geojson
+++ b/data/101/865/381/101865381.geojson
@@ -52,6 +52,9 @@
         "gp:id":929398
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2b56f99a4159cd42a005ac234f026bd",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101865381,
-    "wof:lastmodified":1566595813,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u041a\u0430\u043c'\u044f\u043d\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/383/101865383.geojson
+++ b/data/101/865/383/101865383.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":2
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ac6b5957f49967e464b2acb18b109a5",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865383,
-    "wof:lastmodified":1566595805,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0410\u0432\u0433\u0443\u0441\u0442\u0456\u0432\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/385/101865385.geojson
+++ b/data/101/865/385/101865385.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q4199636"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72535d06f0285f6a184d9d50a1f53ea1",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101865385,
-    "wof:lastmodified":1566595805,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0406\u043b\u043b\u0456\u043d\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/387/101865387.geojson
+++ b/data/101/865/387/101865387.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Bilyayivka"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"744bf8b0a36491ebaae516bcddd69ff4",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":101865387,
-    "wof:lastmodified":1566595813,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0411\u0456\u043b\u044f\u0457\u0432\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/389/101865389.geojson
+++ b/data/101/865/389/101865389.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb481f3f54f9739ca2c51630e0fcb70d",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865389,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0425\u043b\u0456\u0431\u043e\u0434\u0430\u0440\u0441\u044c\u043a\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/391/101865391.geojson
+++ b/data/101/865/391/101865391.geojson
@@ -139,6 +139,9 @@
         "wk:page":"Teplodar"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c278aa5a5470a039c89be11113500d4a",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101865391,
-    "wof:lastmodified":1566595800,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0422\u0435\u043f\u043b\u043e\u0434\u0430\u0440",
     "wof:parent_id":1108730693,
     "wof:placetype":"locality",

--- a/data/101/865/397/101865397.geojson
+++ b/data/101/865/397/101865397.geojson
@@ -75,6 +75,9 @@
         "wd:id":"Q4111663"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"87c77395aaef67d02ab34b85e5de5885",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":101865397,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0412\u0438\u043d\u043e\u0433\u0440\u0430\u0434\u0430\u0440",
     "wof:parent_id":102087985,
     "wof:placetype":"locality",

--- a/data/101/865/399/101865399.geojson
+++ b/data/101/865/399/101865399.geojson
@@ -79,6 +79,9 @@
         "wd:id":"Q4528876"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f7a8735ddb91d1362d073df8ca91c00",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":101865399,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0429\u0435\u0440\u0431\u0430\u043d\u043a\u0430",
     "wof:parent_id":102087985,
     "wof:placetype":"locality",

--- a/data/101/865/401/101865401.geojson
+++ b/data/101/865/401/101865401.geojson
@@ -69,6 +69,9 @@
         "wd:id":"Q4147867"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c7cf42e36808115759212683cf457b0",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":101865401,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0421\u0442\u0435\u043f\u043e\u0432\u0435",
     "wof:parent_id":102087985,
     "wof:placetype":"locality",

--- a/data/101/865/403/101865403.geojson
+++ b/data/101/865/403/101865403.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q4441924"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"669f76af57ab072c6554365f384abcb8",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101865403,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0421\u0442\u0435\u043f\u0430\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087985,
     "wof:placetype":"locality",

--- a/data/101/865/405/101865405.geojson
+++ b/data/101/865/405/101865405.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":2
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1adbe04e608969e22634b90925929fff",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101865405,
-    "wof:lastmodified":1566595810,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041d\u043e\u0432\u043e\u0443\u043a\u0440\u0430\u0457\u043d\u043a\u0430",
     "wof:parent_id":102087985,
     "wof:placetype":"locality",

--- a/data/101/865/407/101865407.geojson
+++ b/data/101/865/407/101865407.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Lymanske (urban-type settlement)"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"225cc03ac8a426454ff65fb7986640cf",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101865407,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041b\u0438\u043c\u0430\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087985,
     "wof:placetype":"locality",

--- a/data/101/865/409/101865409.geojson
+++ b/data/101/865/409/101865409.geojson
@@ -154,6 +154,9 @@
         "wk:page":"Rozdilna"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98c9bd1eb789a7dd0035f15ef8955cb4",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":101865409,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0420\u043e\u0437\u0434\u0456\u043b\u044c\u043d\u0430",
     "wof:parent_id":102087985,
     "wof:placetype":"locality",

--- a/data/101/865/451/101865451.geojson
+++ b/data/101/865/451/101865451.geojson
@@ -148,6 +148,9 @@
         "wd:id":"Q3849531"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b42c012191f579ad6e7d315c30baf071",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":101865451,
-    "wof:lastmodified":1566595810,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0424\u043e\u043d\u0442\u0430\u043d\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/453/101865453.geojson
+++ b/data/101/865/453/101865453.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q4322079"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a787bc3a14596c538e14b94577876d34",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101865453,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041d\u043e\u0432\u0430 \u0414\u043e\u0444\u0456\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/455/101865455.geojson
+++ b/data/101/865/455/101865455.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4234362"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a2d7985179f48a8bd5fbe9e465f3d8f4",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101865455,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041a\u043e\u0440\u0441\u0443\u043d\u0446\u0456",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/457/101865457.geojson
+++ b/data/101/865/457/101865457.geojson
@@ -53,6 +53,9 @@
         "gp:id":924146
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3cd5bbd5ebfc00f4a54c4cfb7ff9668b",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101865457,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041e\u043b\u0435\u043a\u0441\u0430\u043d\u0434\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/459/101865459.geojson
+++ b/data/101/865/459/101865459.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b59e1163e68c7f9a7eafeccf1e7697de",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865459,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0406\u043b\u043b\u0456\u0447\u0456\u0432\u043a\u0430",
     "wof:parent_id":1108730629,
     "wof:placetype":"locality",

--- a/data/101/865/461/101865461.geojson
+++ b/data/101/865/461/101865461.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q4239108"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c8e6cd0c2a5022e4540dd7ad2107f72",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101865461,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u041a\u0440\u0430\u0441\u043d\u043e\u0441\u0456\u043b\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/463/101865463.geojson
+++ b/data/101/865/463/101865463.geojson
@@ -62,6 +62,9 @@
         "gp:id":935566
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9cffc8d7b9cb1aaa582764c9f3c946f",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101865463,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0421\u0432\u0435\u0440\u0434\u043b\u043e\u0432\u0435",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/467/101865467.geojson
+++ b/data/101/865/467/101865467.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32d1776e3e8a929d87ca49fb55462470",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865467,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0412\u0438\u0437\u0438\u0440\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/469/101865469.geojson
+++ b/data/101/865/469/101865469.geojson
@@ -83,6 +83,9 @@
         "wd:id":"Q4240150"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f48b97e60b169ef4e2a059a6b6308802",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101865469,
-    "wof:lastmodified":1566595810,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041a\u0440\u0435\u043c\u0438\u0434\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/471/101865471.geojson
+++ b/data/101/865/471/101865471.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab9cb7b21d59ae5de6247701b2c2e922",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101865471,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041f\u0435\u0440\u0448\u043e\u0442\u0440\u0430\u0432\u043d\u0435\u0432\u0435",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/473/101865473.geojson
+++ b/data/101/865/473/101865473.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"072e487c5a1514e759871b75c03c0b98",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101865473,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041a\u0456\u0440\u043e\u0432\u0435",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/475/101865475.geojson
+++ b/data/101/865/475/101865475.geojson
@@ -72,6 +72,9 @@
         "wd:id":"Q4361001"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a272c1ff7225a0ad2e117980616dba0",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":101865475,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041f\u0435\u0442\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/477/101865477.geojson
+++ b/data/101/865/477/101865477.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4416706"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f415fbd5432d655d7802c49dae9f628",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101865477,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0421\u0435\u0440\u0431\u043a\u0430",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/479/101865479.geojson
+++ b/data/101/865/479/101865479.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3753fe5e972725075c1d640d718a31c",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101865479,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0427\u043e\u0440\u043d\u043e\u043c\u043e\u0440\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/481/101865481.geojson
+++ b/data/101/865/481/101865481.geojson
@@ -59,6 +59,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28887ee589ce11dddc4f65b7c17b42ac",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101865481,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041a\u043e\u043c\u0456\u043d\u0442\u0435\u0440\u043d\u0456\u0432\u0441\u044c\u043a\u0435",
     "wof:parent_id":102087995,
     "wof:placetype":"locality",

--- a/data/101/865/485/101865485.geojson
+++ b/data/101/865/485/101865485.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50440616ae722b682c22cff8510e8692",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865485,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0411\u043b\u0430\u0433\u043e\u0454\u0432\u0435",
     "wof:parent_id":102087997,
     "wof:placetype":"locality",

--- a/data/101/865/487/101865487.geojson
+++ b/data/101/865/487/101865487.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b296e3195e18a4bffbfdf132e61cb79",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865487,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0411\u0443\u0437\u0438\u043d\u043e\u0432\u0435",
     "wof:parent_id":102087997,
     "wof:placetype":"locality",

--- a/data/101/865/489/101865489.geojson
+++ b/data/101/865/489/101865489.geojson
@@ -56,6 +56,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b4faa90c22b2207a028d5b8b46aaaa51",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":101865489,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0427\u0435\u0440\u0432\u043e\u043d\u043e\u0437\u043d\u0430\u043c'\u044f\u043d\u043a\u0430",
     "wof:parent_id":102087997,
     "wof:placetype":"locality",

--- a/data/101/865/491/101865491.geojson
+++ b/data/101/865/491/101865491.geojson
@@ -72,6 +72,9 @@
         "wd:id":"Q704858"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d7e07cc008eda00c13604621ea50ad3",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":101865491,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041a\u043e\u043d\u043e\u043f\u043b\u044f\u043d\u0435",
     "wof:parent_id":102087997,
     "wof:placetype":"locality",

--- a/data/101/865/493/101865493.geojson
+++ b/data/101/865/493/101865493.geojson
@@ -70,6 +70,9 @@
         "wd:id":"Q4361001"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"16ee3da872ef31706e9f279415816272",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":101865493,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041f\u0435\u0442\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087997,
     "wof:placetype":"locality",

--- a/data/101/865/495/101865495.geojson
+++ b/data/101/865/495/101865495.geojson
@@ -61,6 +61,9 @@
         "qs_pg:id":128691
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c10ef806d8f61008e3cc666d560571b",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":101865495,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0406\u0432\u0430\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102087997,
     "wof:placetype":"locality",

--- a/data/101/865/497/101865497.geojson
+++ b/data/101/865/497/101865497.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec4031fc09437af0f7f5f6f2edaec5f9",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865497,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0420\u0430\u0434\u0456\u0441\u043d\u0435",
     "wof:parent_id":102087997,
     "wof:placetype":"locality",

--- a/data/101/865/499/101865499.geojson
+++ b/data/101/865/499/101865499.geojson
@@ -80,6 +80,9 @@
         "wd:id":"Q4148245"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9a513de34632c3dac8158f738948c82",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101865499,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0413\u0440\u0435\u0431\u0435\u043d\u0438\u043a\u0438",
     "wof:parent_id":102088003,
     "wof:placetype":"locality",

--- a/data/101/865/503/101865503.geojson
+++ b/data/101/865/503/101865503.geojson
@@ -95,6 +95,9 @@
         "wd:id":"Q4106770"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4333fb41a93cfcba11458035f3c2f751",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101865503,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u0412\u0435\u043b\u0438\u043a\u043e\u043f\u043b\u043e\u0441\u043a\u0435",
     "wof:parent_id":102088003,
     "wof:placetype":"locality",

--- a/data/101/865/505/101865505.geojson
+++ b/data/101/865/505/101865505.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4324894"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41f5d293511c58829bce6a74f7d11d7d",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101865505,
-    "wof:lastmodified":1566595800,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041d\u043e\u0432\u043e\u043f\u0435\u0442\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088003,
     "wof:placetype":"locality",

--- a/data/101/865/507/101865507.geojson
+++ b/data/101/865/507/101865507.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4106724"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"525e93a0323fc496e853f56fad877848",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101865507,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0412\u0435\u043b\u0438\u043a\u043e\u043a\u043e\u043c\u0430\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088003,
     "wof:placetype":"locality",

--- a/data/101/865/509/101865509.geojson
+++ b/data/101/865/509/101865509.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4323267"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91f195dec690af8a69be71aaeab36618",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101865509,
-    "wof:lastmodified":1566595808,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041d\u043e\u0432\u043e\u0431\u043e\u0440\u0438\u0441\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088003,
     "wof:placetype":"locality",

--- a/data/101/865/511/101865511.geojson
+++ b/data/101/865/511/101865511.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q2652157"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c66d8fae255c2a102fea5f87c7159fc",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101865511,
-    "wof:lastmodified":1566595806,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0412\u0435\u043b\u0438\u043a\u0430 \u041c\u0438\u0445\u0430\u0439\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088003,
     "wof:placetype":"locality",

--- a/data/101/865/513/101865513.geojson
+++ b/data/101/865/513/101865513.geojson
@@ -93,6 +93,9 @@
         "wd:id":"Q169520"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a33b723c6f6a60e7fdecb6797ef67961",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101865513,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0426\u0435\u0431\u0440\u0438\u043a\u043e\u0432\u0435",
     "wof:parent_id":102088003,
     "wof:placetype":"locality",

--- a/data/101/865/593/101865593.geojson
+++ b/data/101/865/593/101865593.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q4165026"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"356ad38aead0784ecd1266f51d3e885e",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101865593,
-    "wof:lastmodified":1566595800,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041f\u0430\u0432\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088023,
     "wof:placetype":"locality",

--- a/data/101/865/595/101865595.geojson
+++ b/data/101/865/595/101865595.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q4350434"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b725220b0c4cf341773f6b8231b6098",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101865595,
-    "wof:lastmodified":1566595801,
+    "wof:lastmodified":1582314095,
     "wof:name":"\u041f\u0435\u0440\u0435\u0445\u0440\u0435\u0441\u0442\u043e\u0432\u0435 \u041f\u0435\u0440\u0448\u0435",
     "wof:parent_id":102088023,
     "wof:placetype":"locality",

--- a/data/101/865/597/101865597.geojson
+++ b/data/101/865/597/101865597.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Zakharivka"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"970cf59ae36ffb3568e165704aea3585",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101865597,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0424\u0440\u0443\u043d\u0437\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088023,
     "wof:placetype":"locality",

--- a/data/101/865/599/101865599.geojson
+++ b/data/101/865/599/101865599.geojson
@@ -116,6 +116,9 @@
         "wd:id":"Q2473528"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9502e12f18c65d26cb1c50a5ba689d8f",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":101865599,
-    "wof:lastmodified":1566595807,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0417\u0430\u0442\u0438\u0448\u0448\u044f",
     "wof:parent_id":102088023,
     "wof:placetype":"locality",

--- a/data/101/865/601/101865601.geojson
+++ b/data/101/865/601/101865601.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q4325229"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ddcb500e6a360c7d1e9982546fd6ca5",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101865601,
-    "wof:lastmodified":1566595810,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041d\u043e\u0432\u043e\u0441\u0430\u043c\u0430\u0440\u043a\u0430",
     "wof:parent_id":102088029,
     "wof:placetype":"locality",

--- a/data/101/865/603/101865603.geojson
+++ b/data/101/865/603/101865603.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q4460645"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bc8eed9e957c640bd8017b81bc557f62",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101865603,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0422\u043e\u043f\u0430\u043b\u0438",
     "wof:parent_id":102088029,
     "wof:placetype":"locality",

--- a/data/101/865/605/101865605.geojson
+++ b/data/101/865/605/101865605.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q4438992"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04b6cc90a3de63431f1de6626b21bbad",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101865605,
-    "wof:lastmodified":1566595803,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0421\u0442\u0430\u0432\u0440\u043e\u0432\u0435",
     "wof:parent_id":102088029,
     "wof:placetype":"locality",

--- a/data/101/865/607/101865607.geojson
+++ b/data/101/865/607/101865607.geojson
@@ -92,6 +92,9 @@
         "wd:id":"Q4518539"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77838f875d9b67e59da5e5e56c4b0364",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101865607,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0427\u043e\u0440\u043d\u0430",
     "wof:parent_id":102088029,
     "wof:placetype":"locality",

--- a/data/101/865/611/101865611.geojson
+++ b/data/101/865/611/101865611.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q1786696"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06452cdd1c58ee447be390ab716b129f",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101865611,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041a\u0440\u0430\u0441\u043d\u0456 \u041e\u043a\u043d\u0438",
     "wof:parent_id":102088029,
     "wof:placetype":"locality",

--- a/data/101/865/613/101865613.geojson
+++ b/data/101/865/613/101865613.geojson
@@ -51,6 +51,9 @@
         "gp:id":916247
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2580c659edbe65d453303bf67f41a9b7",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865613,
-    "wof:lastmodified":1566595808,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0420\u043e\u0437\u043a\u0432\u0456\u0442",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/615/101865615.geojson
+++ b/data/101/865/615/101865615.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"548efb9da2221af234e0b9fc2bec2b0f",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865615,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0421\u0442\u0430\u0432\u043a\u043e\u0432\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/617/101865617.geojson
+++ b/data/101/865/617/101865617.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b1967fee2d036228f5cb53e21a6d1e8",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101865617,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0412\u0438\u043d\u043e\u0433\u0440\u0430\u0434\u043d\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/619/101865619.geojson
+++ b/data/101/865/619/101865619.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q4183160"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d1678e5527ec758c3c1454f8176428db",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101865619,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0417\u0430\u0432\u043e\u0434\u0456\u0432\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/621/101865621.geojson
+++ b/data/101/865/621/101865621.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e9f51c1737e9eb79aefd583bbbce3f3c",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":101865621,
-    "wof:lastmodified":1566595802,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0414\u0435\u043c\u0438\u0434\u043e\u0432\u0435",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/623/101865623.geojson
+++ b/data/101/865/623/101865623.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Berezivka"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"153ab4e71bb9966eb762e99412f8069f",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":101865623,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0411\u0435\u0440\u0435\u0437\u0456\u0432\u043a\u0430",
     "wof:parent_id":85688877,
     "wof:placetype":"locality",

--- a/data/101/865/653/101865653.geojson
+++ b/data/101/865/653/101865653.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Petrovirivka"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"221f4f92999e70ccb32f7e189342a494",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101865653,
-    "wof:lastmodified":1566595811,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0416\u043e\u0432\u0442\u0435\u043d\u044c",
     "wof:parent_id":102088047,
     "wof:placetype":"locality",

--- a/data/101/865/655/101865655.geojson
+++ b/data/101/865/655/101865655.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b67cf4cf46ea5f1a1ee327287488874",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101865655,
-    "wof:lastmodified":1566595809,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u041c\u0430\u0440'\u044f\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088047,
     "wof:placetype":"locality",

--- a/data/101/865/657/101865657.geojson
+++ b/data/101/865/657/101865657.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf70aa781969bc0b417d505631523205",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101865657,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041c\u0438\u043a\u043e\u043b\u0430\u0457\u0432\u043a\u0430",
     "wof:parent_id":102088047,
     "wof:placetype":"locality",

--- a/data/101/865/659/101865659.geojson
+++ b/data/101/865/659/101865659.geojson
@@ -111,6 +111,9 @@
         "wd:id":"Q2993511"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74cd094e4bedf28356e9896222ee7e8d",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101865659,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0428\u0438\u0440\u044f\u0454\u0432\u0435",
     "wof:parent_id":102088047,
     "wof:placetype":"locality",

--- a/data/101/865/715/101865715.geojson
+++ b/data/101/865/715/101865715.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82163d604f4d4bb2c6ee727f69a97fa8",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865715,
-    "wof:lastmodified":1566595805,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u0421\u0442\u0440\u044e\u043a\u043e\u0432\u0435",
     "wof:parent_id":102088075,
     "wof:placetype":"locality",

--- a/data/101/865/719/101865719.geojson
+++ b/data/101/865/719/101865719.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d75f1f0562ea0d3051e0dcb93a38c681",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865719,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0421\u043a\u043e\u0441\u0430\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088075,
     "wof:placetype":"locality",

--- a/data/101/865/721/101865721.geojson
+++ b/data/101/865/721/101865721.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6aa1987d8c5b9d3f1a77e21e2c0ca20a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865721,
-    "wof:lastmodified":1566595812,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0406\u0441\u0430\u0454\u0432\u0435",
     "wof:parent_id":102088075,
     "wof:placetype":"locality",

--- a/data/101/865/723/101865723.geojson
+++ b/data/101/865/723/101865723.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":2
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4e11e848eb4302880d90779c203cecc",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101865723,
-    "wof:lastmodified":1566595806,
+    "wof:lastmodified":1582314097,
     "wof:name":"\u0410\u043d\u0434\u0440\u0456\u0454\u0432\u043e-\u0406\u0432\u0430\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088075,
     "wof:placetype":"locality",

--- a/data/101/865/725/101865725.geojson
+++ b/data/101/865/725/101865725.geojson
@@ -270,6 +270,9 @@
         "wd:id":"Q16461831"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d12123dc8b9d32f033006bca448602e",
     "wof:hierarchy":[
         {
@@ -281,7 +284,7 @@
         }
     ],
     "wof:id":101865725,
-    "wof:lastmodified":1566595804,
+    "wof:lastmodified":1582314096,
     "wof:name":"\u041c\u0438\u043a\u043e\u043b\u0430\u0457\u0432\u043a\u0430",
     "wof:parent_id":102088075,
     "wof:placetype":"locality",

--- a/data/101/865/727/101865727.geojson
+++ b/data/101/865/727/101865727.geojson
@@ -62,6 +62,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"24ea5060e25be2f49a8ea8ed3bcdfc27",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101865727,
-    "wof:lastmodified":1566595813,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u041c\u0430\u0440\u0434\u0430\u0440\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/865/729/101865729.geojson
+++ b/data/101/865/729/101865729.geojson
@@ -96,6 +96,9 @@
         "wd:id":"Q3622393"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7e18be1ad4b6ae290bbe16aa46fab68",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101865729,
-    "wof:lastmodified":1566595813,
+    "wof:lastmodified":1582314098,
     "wof:name":"\u0414\u043e\u043b\u0438\u043d\u0441\u044c\u043a\u0435",
     "wof:parent_id":102088083,
     "wof:placetype":"locality",

--- a/data/101/866/075/101866075.geojson
+++ b/data/101/866/075/101866075.geojson
@@ -62,6 +62,9 @@
         "gp:id":12518235
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9759a4181a2000bf949b235b0c45419c",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101866075,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041d\u043e\u0432\u043e\u0441\u0435\u043b\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/866/079/101866079.geojson
+++ b/data/101/866/079/101866079.geojson
@@ -61,6 +61,9 @@
         "wd:id":"Q6989786"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14fa6d0a0d7343a3fe14e8de79a8229c",
     "wof:hierarchy":[
         {
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":101866079,
-    "wof:lastmodified":1566595780,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041a\u043e\u0441\u0438",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/866/081/101866081.geojson
+++ b/data/101/866/081/101866081.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q4439712"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04847ac38f908bd22dfe9ff7d32afc88",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101866081,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0421\u0442\u0430\u0440\u0430 \u041a\u0443\u043b\u044c\u043d\u0430",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/866/083/101866083.geojson
+++ b/data/101/866/083/101866083.geojson
@@ -56,6 +56,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0a54bdc48870f8a58b47116a9042e2b",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":101866083,
-    "wof:lastmodified":1566595780,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0421\u0442\u0430\u043d\u0456\u0441\u043b\u0430\u0432\u043a\u0430",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/866/085/101866085.geojson
+++ b/data/101/866/085/101866085.geojson
@@ -53,6 +53,9 @@
         "gp:id":925308
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ed2d0685d2c7076aa90933fdb9b0136",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101866085,
-    "wof:lastmodified":1566595781,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041b\u0438\u043f\u0435\u0446\u044c\u043a\u0435",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/866/087/101866087.geojson
+++ b/data/101/866/087/101866087.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4271894"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6fa19d74a2e017d2fc71f4b982ade827",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101866087,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041b\u044e\u0431\u043e\u043c\u0438\u0440\u043a\u0430",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/866/089/101866089.geojson
+++ b/data/101/866/089/101866089.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4317850"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d3b4003925b231405093a33fdcb576e",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101866089,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041d\u0435\u0441\u0442\u043e\u0457\u0442\u0430",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/866/091/101866091.geojson
+++ b/data/101/866/091/101866091.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23266c4d101d25b2c150d1a4d9d8cac6",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101866091,
-    "wof:lastmodified":1566595781,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0411\u043e\u0440\u0449\u0456",
     "wof:parent_id":102088079,
     "wof:placetype":"locality",

--- a/data/101/866/099/101866099.geojson
+++ b/data/101/866/099/101866099.geojson
@@ -90,6 +90,9 @@
         "wd:id":"Q3622470"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"162e2f682d72e226c46505786841d531",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101866099,
-    "wof:lastmodified":1566595781,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0413\u0430\u043d\u0434\u0440\u0430\u0431\u0443\u0440\u0438",
     "wof:parent_id":102088083,
     "wof:placetype":"locality",

--- a/data/101/866/101/101866101.geojson
+++ b/data/101/866/101/101866101.geojson
@@ -139,6 +139,9 @@
         "wd:id":"Q485891"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6416354deefa07836780c0b9d303b210",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101866101,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0410\u043d\u0430\u043d\u044c\u0457\u0432",
     "wof:parent_id":102088083,
     "wof:placetype":"locality",

--- a/data/101/866/103/101866103.geojson
+++ b/data/101/866/103/101866103.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q3622622"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af3bbeb865036100d3970911bb69a848",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101866103,
-    "wof:lastmodified":1566595779,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0422\u043e\u0447\u0438\u043b\u043e\u0432\u0435",
     "wof:parent_id":102088083,
     "wof:placetype":"locality",

--- a/data/101/866/105/101866105.geojson
+++ b/data/101/866/105/101866105.geojson
@@ -59,6 +59,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4821c055a880545afb6a221dbe46b1bf",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101866105,
-    "wof:lastmodified":1566595780,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041d\u043e\u0432\u043e\u0433\u0435\u043e\u0440\u0433\u0456\u0457\u0432\u043a\u0430",
     "wof:parent_id":102088083,
     "wof:placetype":"locality",

--- a/data/101/866/107/101866107.geojson
+++ b/data/101/866/107/101866107.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q3622204"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ea246fec92b7e8e8dad9a7a7f159000",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101866107,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0416\u0435\u0440\u0435\u0431\u043a\u043e\u0432\u0435",
     "wof:parent_id":102088083,
     "wof:placetype":"locality",

--- a/data/101/866/109/101866109.geojson
+++ b/data/101/866/109/101866109.geojson
@@ -157,6 +157,9 @@
         "wd:id":"Q485891"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ae9a931304d87e2b6e3cccea5737917",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":101866109,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0410\u043d\u0430\u043d\u044c\u0457\u0432",
     "wof:parent_id":102088083,
     "wof:placetype":"locality",

--- a/data/101/866/161/101866161.geojson
+++ b/data/101/866/161/101866161.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4523249"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ca30e27400ccb31c1a3e46a853a98fb",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101866161,
-    "wof:lastmodified":1566595780,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0428\u0435\u0440\u0448\u0435\u043d\u0446\u0456",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/163/101866163.geojson
+++ b/data/101/866/163/101866163.geojson
@@ -51,6 +51,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7fe4de916c4af2ab1a434550fcb78b9b",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":101866163,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041b\u0430\u0431\u0443\u0448\u043d\u0435",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/165/101866165.geojson
+++ b/data/101/866/165/101866165.geojson
@@ -92,6 +92,9 @@
         "wd:id":"Q703597"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2cc7b84a8724694f3cff6ae289c3453d",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101866165,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0417\u0430\u0433\u043d\u0456\u0442\u043a\u0456\u0432",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/169/101866169.geojson
+++ b/data/101/866/169/101866169.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q4416724"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b832f24f329b906447b4041b9b5cfe2c",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101866169,
-    "wof:lastmodified":1566595780,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0421\u0435\u0440\u0431\u0438",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/171/101866171.geojson
+++ b/data/101/866/171/101866171.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q579328"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f687d04c1956219fa354ff4952e92d08",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101866171,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0411\u0430\u0448\u0442\u0430\u043d\u043a\u0456\u0432",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/173/101866173.geojson
+++ b/data/101/866/173/101866173.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q551881"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60e9eb5b8d5b0bf7f04117ee58b8fcb5",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":101866173,
-    "wof:lastmodified":1566595781,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0406\u0432\u0430\u0448\u043a\u0456\u0432",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/175/101866175.geojson
+++ b/data/101/866/175/101866175.geojson
@@ -91,6 +91,9 @@
         "wd:id":"Q2998342"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e5248f9a3102089b8018edb533717ecb",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101866175,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0411\u0443\u0434\u0435\u0457",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/177/101866177.geojson
+++ b/data/101/866/177/101866177.geojson
@@ -56,6 +56,9 @@
         "qs_pg:id":2
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3dec649f6229c8e01ab1b87200536e3e",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":101866177,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041f\u0438\u0440\u0456\u0436\u043d\u0430",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/179/101866179.geojson
+++ b/data/101/866/179/101866179.geojson
@@ -108,6 +108,9 @@
         "wd:id":"Q945397"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e811f29eb4a4b211e8e04d762df6628",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":101866179,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0421\u043b\u043e\u0431\u0456\u0434\u043a\u0430",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/181/101866181.geojson
+++ b/data/101/866/181/101866181.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Kodyma"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41813f6daa2bebe7ffb803b05efaabf0",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":101866181,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041a\u043e\u0434\u0438\u043c\u0430",
     "wof:parent_id":102088113,
     "wof:placetype":"locality",

--- a/data/101/866/211/101866211.geojson
+++ b/data/101/866/211/101866211.geojson
@@ -57,6 +57,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3286dfc6f398005436ffc83fc4ecad3c",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":101866211,
-    "wof:lastmodified":1566595780,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0422\u0440\u043e\u0457\u0446\u044c\u043a\u0435",
     "wof:parent_id":102088121,
     "wof:placetype":"locality",

--- a/data/101/866/213/101866213.geojson
+++ b/data/101/866/213/101866213.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"458eb79d4a42fae3697dbca79ec65462",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866213,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0421\u043e\u043b\u0442\u0430\u043d\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088121,
     "wof:placetype":"locality",

--- a/data/101/866/215/101866215.geojson
+++ b/data/101/866/215/101866215.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":4
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"13f67c47738be8de7c259e5e8f7dec87",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866215,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0413\u0432\u043e\u0437\u0434\u0430\u0432\u043a\u0430 \u0414\u0440\u0443\u0433\u0430",
     "wof:parent_id":102088121,
     "wof:placetype":"locality",

--- a/data/101/866/217/101866217.geojson
+++ b/data/101/866/217/101866217.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"034a347fcb31636bbc90ea327ad443de",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866217,
-    "wof:lastmodified":1566595781,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u042f\u0441\u0435\u043d\u043e\u0432\u0435 \u0414\u0440\u0443\u0433\u0435",
     "wof:parent_id":102088121,
     "wof:placetype":"locality",

--- a/data/101/866/219/101866219.geojson
+++ b/data/101/866/219/101866219.geojson
@@ -119,6 +119,9 @@
         "wd:id":"Q1866731"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f60b68b4c48cfc7961cd9d612c2478d3",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101866219,
-    "wof:lastmodified":1566595780,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041b\u044e\u0431\u0430\u0448\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088121,
     "wof:placetype":"locality",

--- a/data/101/866/223/101866223.geojson
+++ b/data/101/866/223/101866223.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62c03f5f9345f71b24ce071f5bcceb59",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866223,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0417\u0435\u043b\u0435\u043d\u043e\u0433\u0456\u0440\u0441\u044c\u043a\u0435",
     "wof:parent_id":102088121,
     "wof:placetype":"locality",

--- a/data/101/866/317/101866317.geojson
+++ b/data/101/866/317/101866317.geojson
@@ -62,6 +62,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2adf6cfb60f25067282a378581570347",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":101866317,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041f\u0430\u0441\u0438\u0446\u0435\u043b\u0438",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/101/866/319/101866319.geojson
+++ b/data/101/866/319/101866319.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q4081954"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"41ac97865c43644df3d1123433db18d5",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101866319,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0411\u0456\u043b\u0438\u043d\u0435",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/101/866/321/101866321.geojson
+++ b/data/101/866/321/101866321.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":3
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38ff971501745f7720bb01055a6f8c60",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866321,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041f\u0443\u0436\u0430\u0439\u043a\u043e\u0432\u0435",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/101/866/323/101866323.geojson
+++ b/data/101/866/323/101866323.geojson
@@ -55,6 +55,9 @@
         "qs_pg:id":128364
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc5027a5befc21cc9896389e9c4a6e44",
     "wof:hierarchy":[
         {
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":101866323,
-    "wof:lastmodified":1566595781,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041f\u0456\u0449\u0430\u043d\u0430",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/101/866/325/101866325.geojson
+++ b/data/101/866/325/101866325.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":2
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64fc71c95851b8649f7eb5321812c67e",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101866325,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0427\u0435\u0440\u043d\u0435\u0447\u0435",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/101/866/327/101866327.geojson
+++ b/data/101/866/327/101866327.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"452f650ff8770ead490a1e2e5752f566",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101866327,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0421\u0430\u0440\u0430\u0436\u0438\u043d\u043a\u0430",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/101/866/359/101866359.geojson
+++ b/data/101/866/359/101866359.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q4076148"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"076d99e57ecca477fa651fbe5d979aef",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101866359,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0411\u0430\u043a\u0448\u0430",
     "wof:parent_id":102088165,
     "wof:placetype":"locality",

--- a/data/101/866/361/101866361.geojson
+++ b/data/101/866/361/101866361.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8559f77b4248ebae78ee35aa49734f0a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866361,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0411\u0430\u0439\u0431\u0443\u0437\u0456\u0432\u043a\u0430",
     "wof:parent_id":102088165,
     "wof:placetype":"locality",

--- a/data/101/866/363/101866363.geojson
+++ b/data/101/866/363/101866363.geojson
@@ -53,6 +53,9 @@
         "qs_pg:id":9
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f1f33aff121515b435750c165b80467c",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":101866363,
-    "wof:lastmodified":1566595780,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041a\u043e\u043d\u0446\u0435\u0431\u0430",
     "wof:parent_id":102088165,
     "wof:placetype":"locality",

--- a/data/101/866/367/101866367.geojson
+++ b/data/101/866/367/101866367.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cda150b5491bcae019918528f05dac41",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866367,
-    "wof:lastmodified":1566595783,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041e\u0441\u0438\u0447\u043a\u0438",
     "wof:parent_id":102088165,
     "wof:placetype":"locality",

--- a/data/101/866/369/101866369.geojson
+++ b/data/101/866/369/101866369.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q4371479"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0eba4ed8d817b04c9d6861956594baae",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101866369,
-    "wof:lastmodified":1566595782,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041f\u043e\u043b\u044f\u043d\u0435\u0446\u044c\u043a\u0435",
     "wof:parent_id":102088165,
     "wof:placetype":"locality",

--- a/data/101/866/371/101866371.geojson
+++ b/data/101/866/371/101866371.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":6
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a593d5cce9b5aca9e973030d497e6cd",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866371,
-    "wof:lastmodified":1566595781,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0414\u0443\u0431\u0438\u043d\u043e\u0432\u0435",
     "wof:parent_id":102088165,
     "wof:placetype":"locality",

--- a/data/101/866/373/101866373.geojson
+++ b/data/101/866/373/101866373.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f484a65c0b040a63f03cec4f5a3a35b",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101866373,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u041a\u0430\u043c'\u044f\u043d\u0435",
     "wof:parent_id":102088165,
     "wof:placetype":"locality",

--- a/data/101/866/375/101866375.geojson
+++ b/data/101/866/375/101866375.geojson
@@ -127,6 +127,9 @@
         "wk:page":"Savran, Odessa Oblast"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0915188b08acb7c5cb3855856f002e71",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101866375,
-    "wof:lastmodified":1566595784,
+    "wof:lastmodified":1582314092,
     "wof:name":"\u0421\u0430\u0432\u0440\u0430\u043d\u044c",
     "wof:parent_id":102088165,
     "wof:placetype":"locality",

--- a/data/101/873/103/101873103.geojson
+++ b/data/101/873/103/101873103.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":7
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00ca7ca7fe58e0de8954c03e66012c02",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101873103,
-    "wof:lastmodified":1566595778,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0420\u043e\u0439\u043b\u044f\u043d\u043a\u0430",
     "wof:parent_id":102087941,
     "wof:placetype":"locality",

--- a/data/101/873/105/101873105.geojson
+++ b/data/101/873/105/101873105.geojson
@@ -56,6 +56,9 @@
         "qs_pg:id":1
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ede8f6dbeaaa8789c3899c79f55bf2c3",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":101873105,
-    "wof:lastmodified":1566595778,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0421\u0442\u0430\u0440\u0430 \u0426\u0430\u0440\u0438\u0447\u0430\u043d\u043a\u0430",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/873/107/101873107.geojson
+++ b/data/101/873/107/101873107.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a92f749c5ce6a9ded69b033426e20509",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101873107,
-    "wof:lastmodified":1566595779,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u041a\u0430\u043b\u0430\u0433\u043b\u0456\u044f",
     "wof:parent_id":102087967,
     "wof:placetype":"locality",

--- a/data/101/873/137/101873137.geojson
+++ b/data/101/873/137/101873137.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q2998342"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a769d02007d71b69294e1093a312465b",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101873137,
-    "wof:lastmodified":1566595779,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0413\u043e\u043b\u044c\u043c\u0430",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/101/873/139/101873139.geojson
+++ b/data/101/873/139/101873139.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q4083715"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"deaf35e1ed195033a4de3363119cb610",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101873139,
-    "wof:lastmodified":1566595779,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0411\u0435\u043d\u0434\u0437\u0430\u0440\u0438",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/101/873/951/101873951.geojson
+++ b/data/101/873/951/101873951.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q584935"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aa69c8c32800eda3a0ec551157703a31",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101873951,
-    "wof:lastmodified":1566595779,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0411\u043e\u0440\u043e\u0434\u0456\u043d\u043e",
     "wof:parent_id":102087949,
     "wof:placetype":"locality",

--- a/data/101/873/953/101873953.geojson
+++ b/data/101/873/953/101873953.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":5
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3388effef78b5b5e2ab9fde01a7bab28",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101873953,
-    "wof:lastmodified":1566595778,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0412\u0438\u043f\u0430\u0441\u043d\u0435",
     "wof:parent_id":102087951,
     "wof:placetype":"locality",

--- a/data/101/873/955/101873955.geojson
+++ b/data/101/873/955/101873955.geojson
@@ -184,6 +184,9 @@
         "wk:page":"Balta, Odessa Oblast"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1051de6d14a896a99ad447f2ebca3ac3",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":101873955,
-    "wof:lastmodified":1566595778,
+    "wof:lastmodified":1582314091,
     "wof:name":"\u0411\u0430\u043b\u0442\u0430",
     "wof:parent_id":102088151,
     "wof:placetype":"locality",

--- a/data/859/017/59/85901759.geojson
+++ b/data/859/017/59/85901759.geojson
@@ -67,6 +67,9 @@
         "gp:id":871089
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bea2d571ef404bb22a20d669ba6f75aa",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "rum"
     ],
-    "wof:lastmodified":1566595776,
+    "wof:lastmodified":1582314090,
     "wof:name":"Dealu Cet\u0103\u021bii",
     "wof:parent_id":101833687,
     "wof:placetype":"neighbourhood",

--- a/data/859/026/11/85902611.geojson
+++ b/data/859/026/11/85902611.geojson
@@ -395,6 +395,10 @@
         "wk:page":"Simferopol"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b84a8590e68a65af9cd64c5ac93be773",
     "wof:hierarchy":[
         {
@@ -418,7 +422,7 @@
         }
     ],
     "wof:id":85902611,
-    "wof:lastmodified":1566595776,
+    "wof:lastmodified":1582314090,
     "wof:name":"Ak-Mechet",
     "wof:parent_id":101752789,
     "wof:placetype":"neighbourhood",

--- a/data/859/026/17/85902617.geojson
+++ b/data/859/026/17/85902617.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1175103
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90ad699bd91609373099007b7aba5839",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566595776,
+    "wof:lastmodified":1582314090,
     "wof:name":"Novaya Darnitsa",
     "wof:parent_id":101752489,
     "wof:placetype":"neighbourhood",

--- a/data/859/026/19/85902619.geojson
+++ b/data/859/026/19/85902619.geojson
@@ -80,6 +80,9 @@
         "wd:id":"Q4384871"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b39cb4ee462672be134e150d1089cb5",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566595776,
+    "wof:lastmodified":1582314090,
     "wof:name":"Pushcha-Voditsa",
     "wof:parent_id":101752489,
     "wof:placetype":"neighbourhood",

--- a/data/859/026/21/85902621.geojson
+++ b/data/859/026/21/85902621.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":235402
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"38093fa62f8de1cef061cdb721d56b0e",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566595776,
+    "wof:lastmodified":1582314090,
     "wof:name":"Staraya Darnitsa",
     "wof:parent_id":101752489,
     "wof:placetype":"neighbourhood",

--- a/data/859/026/23/85902623.geojson
+++ b/data/859/026/23/85902623.geojson
@@ -92,6 +92,9 @@
         "wd:id":"Q4403870"
     },
     "wof:country":"UK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d54be95a71cec2e091bdf213af1d2556",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566595777,
+    "wof:lastmodified":1582314090,
     "wof:name":"Varvarovka",
     "wof:parent_id":101752809,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.